### PR TITLE
chore: prepare to use rolling tags

### DIFF
--- a/.config/cliff.toml
+++ b/.config/cliff.toml
@@ -123,6 +123,9 @@ filter_commits = true
 topo_order = false
 # sort the commits inside sections by oldest/newest order
 sort_commits = "oldest"
+# Ignore rolling tags for major and minor versions.
+# Only use tags with full version.
+tag_pattern = "v[0-9]+.[0-9]+.[0-9]+"
 
 [remote.github]
 owner = "2bndy5"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ on:
       - Cargo.toml
       - .github/workflows/rust.yml
     tags:
-      - v*
+      - v*.*.*
   pull_request:
     branches: [main]
     paths:
@@ -156,7 +156,7 @@ jobs:
           path: report-size-deltas-${{ matrix.target }}*
           if-no-files-found: error
 
-  publish:
+  release:
     if: startswith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
     needs: [build]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ on:
       - Cargo.toml
       - .github/workflows/rust.yml
     tags:
-      - v*.*.*
+      - 'v+([0-9]).+([0-9]).+([0-9])'
   pull_request:
     branches: [main]
     paths:


### PR DESCRIPTION
In anticipation of deploying v1.0.0, there are typically rolling tags like `v1` or `v1.2` for major and minor versions updates. This practice is rather common to deploying GitHub Actions.

- Adjusts the CI trigger to only build binaries for fully qualified tags.
- Update bump-n-release.nu script to automate managing these rolling tags.
- Adjust the git-cliff config so only fully-qualified tags are used in generating the changelog; essentially ignoring the rolling tags.