### PR TITLE
feat: make serde types more convenient

### DIFF
--- a/nurfile
+++ b/nurfile
@@ -68,7 +68,7 @@ export def "nur lint" [
     --check (-c), # Only check, do not fix
     --no-features (-n), # Do not include features when linting
 ] {
-    mut clippy = [cargo clippy]
+    mut clippy = [cargo clippy --all-targets]
     if (not $no_features) {
         $clippy = $clippy | append [--features bin]
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../README.md")]
+#![deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
 mod error;
 mod reports;

--- a/src/reports/mod.rs
+++ b/src/reports/mod.rs
@@ -63,6 +63,8 @@ pub fn parse_artifacts<P: AsRef<Path>>(
 
 #[cfg(test)]
 mod test {
+    #![allow(clippy::unwrap_used)]
+
     use std::io::Write;
 
     use super::{JsonError, parse_json};

--- a/src/reports/structs.rs
+++ b/src/reports/structs.rs
@@ -248,18 +248,11 @@ where
         type Value = (); // We want to return unit
 
         fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-            formatter.write_str("any string")
+            formatter.write_str("any `&str` value")
         }
 
         // Accept any string and simply return ()
         fn visit_str<E>(self, _value: &str) -> Result<(), E>
-        where
-            E: serde::de::Error,
-        {
-            Ok(())
-        }
-
-        fn visit_string<E>(self, _value: String) -> Result<(), E>
         where
             E: serde::de::Error,
         {
@@ -380,18 +373,5 @@ mod test {
         let size_value = SizeValue::<u8>::NotApplicable;
         let serialized = serde_json::to_string(&size_value).unwrap();
         assert_eq!(serialized, r#""N/A""#);
-    }
-
-    #[test]
-    fn deserialize_not_applicable() {
-        use serde::de::{
-            Deserialize, IntoDeserializer,
-            value::{Error as ValueError, StringDeserializer},
-        };
-
-        let input = r#""N/A""#.to_string();
-        let deserializer: StringDeserializer<ValueError> = input.into_deserializer();
-        let deserialized: SizeValue<u8> = SizeValue::deserialize(deserializer).unwrap();
-        assert_eq!(deserialized, SizeValue::NotApplicable);
     }
 }

--- a/src/reports/structs.rs
+++ b/src/reports/structs.rs
@@ -12,7 +12,7 @@
 //! There doesn't seem to be a documented schema for the JSON data being parsed.'
 //! All python code producing the JSON data is partially typed, so it hard to
 //! discern a proper schema.
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Visitor};
 
 /// The root structure that describes a report about compilation.
 #[derive(Debug, Deserialize, Default, Serialize)]
@@ -36,13 +36,15 @@ impl Report {
             return false;
         }
         for board in &self.boards {
-            if board.sizes.is_none() || board.sizes.as_ref().is_some_and(|v| v.is_empty()) {
-                return false;
-            }
-            // unwrap() yields Some value because of the check above
-            for size in board.sizes.as_ref().unwrap() {
-                if !size.has_maximum() {
-                    return false;
+            match &board.sizes {
+                Some(sizes) if sizes.is_empty() => return false,
+                None => return false,
+                Some(sizes) => {
+                    for size in sizes {
+                        if !size.has_maximum() {
+                            return false;
+                        }
+                    }
                 }
             }
         }
@@ -201,21 +203,79 @@ impl Default for SketchSizeKind {
     }
 }
 
+impl SketchSizeKind {
+    /// A convenience function to get the inner [`SketchSize`].
+    pub fn get_size(&self) -> &SketchSize {
+        match self {
+            SketchSizeKind::Ram { size } => size,
+            SketchSizeKind::Flash { size } => size,
+        }
+    }
+
+    /// A convenience function to get a mutable reference to the inner [`SketchSize`].
+    pub fn get_size_mut(&mut self) -> &mut SketchSize {
+        match self {
+            SketchSizeKind::Ram { size } => size,
+            SketchSizeKind::Flash { size } => size,
+        }
+    }
+}
+
 /// An enumeration of the possible values used to describe a compilation's size.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, Default, PartialEq, Eq)]
 #[serde(untagged)]
 pub enum SizeValue<T> {
     /// Represents a "Not Applicable" (N/A) value.
-    NotApplicable(String),
+    #[default]
+    #[serde(
+        deserialize_with = "any_str_val_is_not_applicable",
+        serialize_with = "not_applicable_to_string"
+    )]
+    NotApplicable,
 
     /// Represents a known value.
     Known(T),
 }
 
-impl<T> Default for SizeValue<T> {
-    fn default() -> Self {
-        SizeValue::NotApplicable(String::from("N/A"))
+/// Custom deserializer function
+fn any_str_val_is_not_applicable<'de, D>(deserializer: D) -> Result<(), D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct StringIgnorer;
+
+    impl<'de> Visitor<'de> for StringIgnorer {
+        type Value = (); // We want to return unit
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("any string")
+        }
+
+        // Accept any string and simply return ()
+        fn visit_str<E>(self, _value: &str) -> Result<(), E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(())
+        }
+
+        fn visit_string<E>(self, _value: String) -> Result<(), E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(())
+        }
     }
+
+    deserializer.deserialize_string(StringIgnorer)
+}
+
+/// Custom serializer function
+fn not_applicable_to_string<S>(serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_str("N/A")
 }
 
 /// A data structure to describe fields in [`SketchSize`].
@@ -267,7 +327,7 @@ impl BoardSize {
 
 #[cfg(test)]
 mod test {
-    use crate::report_structs::BoardSize;
+    use crate::report_structs::{BoardSize, SizeValue};
 
     use super::{Report, SketchSize, SketchSizeKind};
 
@@ -295,5 +355,21 @@ mod test {
             BoardSize::default(),
             BoardSize::Flash { maximum: None }
         ));
+    }
+
+    #[test]
+    fn sketch_kind_sizes() {
+        let altered_value = Some(SizeValue::Known(42));
+        for mut sketch_size_kind in [
+            SketchSizeKind::Flash {
+                size: SketchSize::default(),
+            },
+            SketchSizeKind::Ram {
+                size: SketchSize::default(),
+            },
+        ] {
+            sketch_size_kind.get_size_mut().maximum = altered_value;
+            assert_eq!(sketch_size_kind.get_size().maximum, altered_value);
+        }
     }
 }

--- a/src/reports/structs.rs
+++ b/src/reports/structs.rs
@@ -327,6 +327,8 @@ impl BoardSize {
 
 #[cfg(test)]
 mod test {
+    #![allow(clippy::unwrap_used)]
+
     use crate::report_structs::{BoardSize, SizeValue};
 
     use super::{Report, SketchSize, SketchSizeKind};
@@ -371,5 +373,25 @@ mod test {
             sketch_size_kind.get_size_mut().maximum = altered_value;
             assert_eq!(sketch_size_kind.get_size().maximum, altered_value);
         }
+    }
+
+    #[test]
+    fn serialize_not_applicable() {
+        let size_value = SizeValue::<u8>::NotApplicable;
+        let serialized = serde_json::to_string(&size_value).unwrap();
+        assert_eq!(serialized, r#""N/A""#);
+    }
+
+    #[test]
+    fn deserialize_not_applicable() {
+        use serde::de::{
+            Deserialize, IntoDeserializer,
+            value::{Error as ValueError, StringDeserializer},
+        };
+
+        let input = r#""N/A""#.to_string();
+        let deserializer: StringDeserializer<ValueError> = input.into_deserializer();
+        let deserialized: SizeValue<u8> = SizeValue::deserialize(deserializer).unwrap();
+        assert_eq!(deserialized, SizeValue::NotApplicable);
     }
 }

--- a/src/summarize/helpers.rs
+++ b/src/summarize/helpers.rs
@@ -139,6 +139,8 @@ pub(super) fn generate_detailed_table(reports: &Vec<Report>, comment: &mut Strin
 
 #[cfg(test)]
 mod test {
+    #![allow(clippy::unwrap_used)]
+
     use crate::{
         reports::{parse_json, structs::Report},
         summarize::helpers::{END_DETAILS, GENERAL_HEADER, START_DETAILS},

--- a/src/summarize/mod.rs
+++ b/src/summarize/mod.rs
@@ -35,6 +35,8 @@ pub fn generate_comment<P: AsRef<Path>>(sketches_path: P) -> Result<String, Comm
 
 #[cfg(test)]
 mod test {
+    #![allow(clippy::unwrap_used)]
+
     use super::{CommentAssemblyError, generate_comment};
     use std::fs;
 

--- a/src/summarize/structs.rs
+++ b/src/summarize/structs.rs
@@ -30,7 +30,7 @@ impl SizeKind {
                 }
                 format!("{v}")
             }
-            SizeValue::NotApplicable(v) => v.clone(),
+            SizeValue::NotApplicable => "N/A".to_string(),
         }
     }
 }
@@ -57,7 +57,7 @@ impl SizeDeltaRange {
     /// [`Self::maximum`] [`SizeKind::absolute`] values.
     fn add_absolute(&mut self, size: i64) {
         match self.minimum.absolute {
-            SizeValue::NotApplicable(_) => {
+            SizeValue::NotApplicable => {
                 self.minimum.absolute = SizeValue::Known(size);
             }
             SizeValue::Known(val) => {
@@ -67,7 +67,7 @@ impl SizeDeltaRange {
             }
         }
         match self.maximum.absolute {
-            SizeValue::NotApplicable(_) => {
+            SizeValue::NotApplicable => {
                 self.maximum.absolute = SizeValue::Known(size);
             }
             SizeValue::Known(val) => {
@@ -82,7 +82,7 @@ impl SizeDeltaRange {
     /// [`Self::maximum`] [`SizeKind::relative`] values.
     fn add_relative(&mut self, size: f32) {
         match self.minimum.relative {
-            SizeValue::NotApplicable(_) => {
+            SizeValue::NotApplicable => {
                 self.minimum.relative = SizeValue::Known(size);
             }
             SizeValue::Known(val) => {
@@ -92,7 +92,7 @@ impl SizeDeltaRange {
             }
         }
         match self.maximum.relative {
-            SizeValue::NotApplicable(_) => {
+            SizeValue::NotApplicable => {
                 self.maximum.relative = SizeValue::Known(size);
             }
             SizeValue::Known(val) => {


### PR DESCRIPTION
- add `get_size()` and `get_size_mut()` to `SketchSizeKind`
- allow `SizeValue` to be copied, cloned, and compared.
- strictly dissallow `unwrap()`, `expect()`, and `panic!()` in production code. Expand linting with `--all-targets`.

This might be considered a breaking change because `SizeValue::NotApplicable` no longer wraps the JSON string value. Instead, any JSON string value is interpreted to be `NotApplicable`. Similarly, serializing the `SizeValue::NotApplicable` variant yields a `"N/A"` string value.