### PR TITLE
fix: serialize `SketchSizeKind` and `BoardSize` properly

### DIFF
--- a/cspell.config.yml
+++ b/cspell.config.yml
@@ -41,3 +41,4 @@ ignorePaths:
   - .gitattributes
   - .gitignore
   - CHANGELOG.md
+  - tests/**/*.json

--- a/src/reports/structs.rs
+++ b/src/reports/structs.rs
@@ -179,14 +179,14 @@ impl SketchSize {
 #[serde(tag = "name")]
 pub enum SketchSizeKind {
     /// The compilation size of "Ram for global variables".
-    #[serde(rename(deserialize = "RAM for global variables"))]
+    #[serde(rename = "RAM for global variables")]
     Ram {
         #[serde(flatten)]
         size: SketchSize,
     },
 
     /// The compilation size of flash memory.
-    #[serde(rename(deserialize = "flash"))]
+    #[serde(rename = "flash")]
     Flash {
         #[serde(flatten)]
         size: SketchSize,
@@ -238,10 +238,10 @@ pub struct SketchDeltaSize {
 #[serde(tag = "name")]
 pub enum BoardSize {
     /// The maximum size of "RAM for global variables".
-    #[serde(rename(deserialize = "RAM for global variables"))]
+    #[serde(rename = "RAM for global variables")]
     Ram { maximum: Option<SizeValue<u64>> },
     /// The maximum size of flash memory.
-    #[serde(rename(deserialize = "flash"))]
+    #[serde(rename = "flash")]
     Flash { maximum: Option<SizeValue<u64>> },
 }
 


### PR DESCRIPTION
I just needed to rename the tagged enums with the same `"name"` value used for deserialization.

Also ignore spelling in test JSON assets.