### PR TITLE
style: cap the f32 precision of relative deltas

### DIFF
--- a/src/summarize/structs.rs
+++ b/src/summarize/structs.rs
@@ -1,6 +1,6 @@
 //! A module to declare the data structures used to aggregate data from [`crate::reports::structs`].
 use crate::reports::structs::{SizeValue, SketchSizeKind};
-use std::fmt::Display;
+use std::{any::TypeId, fmt::Display};
 
 /// A data structure to represent absolute or relative changes in memory size.
 #[derive(Debug, Default)]
@@ -22,13 +22,26 @@ impl SizeKind {
     ///
     /// This basically just adds a "+" to positive numbers.
     /// Negative or zero `value`s are simply converted to a [`String`].
-    pub fn fmt<T: PartialOrd + Display + Default>(value: &SizeValue<T>) -> String {
+    pub fn fmt<T>(value: &SizeValue<T>) -> String
+    where
+        T: PartialOrd + Display + Default + Sized + 'static,
+    {
         match value {
             SizeValue::Known(v) => {
-                if *v > T::default() {
-                    return format!("+{v}");
-                }
-                format!("{v}")
+                let prefix = if *v > T::default() { "+" } else { "" };
+                let value = if TypeId::of::<T>() == TypeId::of::<f32>() {
+                    format!("{v:.3}")
+                        .trim_end_matches('0')
+                        // If all decimal places were `0`, we should
+                        // trim the insignificant decimal point also.
+                        // This has to be done separately to avoid
+                        // trimming a significant zero representing an integer.
+                        .trim_end_matches('.')
+                        .to_string()
+                } else {
+                    v.to_string()
+                };
+                format!("{prefix}{value}")
             }
             SizeValue::NotApplicable => "N/A".to_string(),
         }


### PR DESCRIPTION
If the JSON report contains known relative delta sizes, the de-serialized f32 may have very long fractional precision. This patch, when adding this relative delta info to the comment, caps the precision to a maximum of 3 decimal places.

The original action doesn't do this. It relies on `arduino/compile-sketches` to cap the relative delta data (to 2 decimal places) before serializing the JSON reports.

Since long decimal places really only affect the length of the comment, it makes more sense to cap the precision when generating the comment. This way other forms of consumption (beside `arduino/report-size-deltas`) can benefit from better precision in the JSON report.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved formatting for numeric summary values.
  * Floating-point values now display with up to three decimal places, trimming trailing zeros and any unnecessary decimal point.
  * Positive values now include an explicit plus sign for clearer comparisons.
  * Numeric output is rendered more consistently to improve readability across value ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->